### PR TITLE
Remove unecessary check.

### DIFF
--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -14,7 +14,7 @@ contract SafeMath {
 
   function safeAdd(uint a, uint b) internal returns (uint) {
     uint c = a + b;
-    assert(c>=a && c>=b);
+    assert(c>=a);
     return c;
   }
 


### PR DESCRIPTION
c>=a
is enough to check for overflow. Because we can't wrap around more than once.
In case of overflow we both have a+b<a and a+b<b.
So c>=b is an unnecessary check increasing gas cost and code length.